### PR TITLE
Return when total free pages falls below high watermark

### DIFF
--- a/predict.c
+++ b/predict.c
@@ -153,10 +153,11 @@ predict(struct frag_info *frag_vec, struct lsq_struct *lsq,
 	}
 
 	if (!is_ready)
-		return retval;
+		goto retval;
 
 	if (frag_vec[0].free_pages < high_wmark) {
 		retval |= MEMPREDICT_RECLAIM;
+		goto retval;
 	}
 
 	/*
@@ -196,7 +197,7 @@ predict(struct frag_info *frag_vec, struct lsq_struct *lsq,
 			if ((x_cross < mempredict_threshold) &&
 				(x_cross > -mempredict_threshold)) {
 				retval |= MEMPREDICT_COMPACT;
-				return retval;
+				goto retval;
 			}
 		}
 	}
@@ -232,5 +233,6 @@ predict(struct frag_info *frag_vec, struct lsq_struct *lsq,
 		}
 	}
 
+out:
 	return retval;
 }


### PR DESCRIPTION
In predict.c, when total free pages falls below high watermark, we
currently do not return to predictord. This could to overflows in
time_taken variable as (frag_vec[0].free_pages - high_wmark) will become
negative in such cases.

Fix this by returning when we notice that total free pages is below high
watermark. We have to reclaim pages anyways in this case.

Signed-off-by: Bharath Vedartham <linux.bhar@gmail.com>