### PR TITLE
Return when total free pages falls below high watermark

### DIFF
--- a/predict.c
+++ b/predict.c
@@ -157,6 +157,7 @@ predict(struct frag_info *frag_vec, struct lsq_struct *lsq,
 
 	if (frag_vec[0].free_pages < high_wmark) {
 		retval |= MEMPREDICT_RECLAIM;
+		return retval;
 	}
 
 	/*


### PR DESCRIPTION
In predict.c, when total free pages falls below high watermark, we
currently do not return to predictord. This could to overflows in
time_taken variable as (frag_vec[0].free_pages - high_wmark) will become
negative in such cases.

Fix this by returning when we notice that total free pages is below high
watermark. We have to reclaim pages anyways in this case.

Signed-off-by: Bharath Vedartham <linux.bhar@gmail.com>